### PR TITLE
Adding documentation, README and Licence

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright 2018 The Frontside Software, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # circleci-react-orb
 
-[CircleCI React Orbs](https://circleci.com/orbs/registry/orb/thefrontside/react) makes it easy to run tests, linting and code coverage on CircleCI.
+[CircleCI React Orbs](https://circleci.com/orbs/registry/orb/thefrontside/react) makes it easy to run tests, linting and code coverage on CircleCI. 
 
 ## Features
 
@@ -14,8 +14,12 @@
 ## Limitations
 
 - Currently only supports yarn (we'll add NPM support shortly)
+- Current Orb assumes: Jest, ESLint and Stylelint
+- TypeScript not supported yet, but will be in the future
 
-## Example
+## Basic setup
+
+The smallest meaningful setup is to run tests on every PR. To do this, you need the following configuration.
 
 ```yaml
 version: 2.1
@@ -28,32 +32,83 @@ workflows:
   push:
     jobs:
       - react/install
-      - react/eslint:
+      - react/test
           requires:
             - react/install
-      - react/stylelint:
-          requires:
-            - react/install
-      - react/test:
-          requires:
-            - react/install
-      - react/coverage:
-          requires:
-            - react/install
-  # push workflow will be triggered when a build is created
-  build:
-    jobs:
-      - react/install
-      - react/eslint:
-          requires:
-            - react/install
-      - react/stylelint:
-          requires:
-            - react/install
-      - react/test:
-          requires:
-            - react/install
-      - react/build:
-            requires:
-              - react/install
 ```
+
+## Adding ESLint to your project
+
+For `eslint` to run successfully, you need an `eslint` script to be present in your package.json. 
+
+You can add it by doing the following,
+
+1. `yarn add --dev eslint`
+2. Add `eslintConfig` to package.json or create an `.eslintrc` file. The minimum configuration is this:
+  ```json
+  {
+    ...
+    "eslintConfig": {
+      "extends": "react-app"
+    }
+    ...
+  }
+  ```
+3. Add `eslint` script to package.json
+   ```json
+   {
+     "scripts": {
+       ...
+       "eslint": "eslint ./",
+     }
+   }
+   ```
+4. ⛴ it.
+
+## Adding Stylelint to your project
+
+For `stylelint` to run succesfully, you need an `stylelint` script to be present in your package.json
+
+You can add it by doing the following,
+
+1. `yarn add --dev stylelint stylelint-config-standard stylelint-junit-formatter`
+2. Create a `.stylelintrc.js` file with the following
+   ```js
+    module.exports = {
+      extends: 'stylelint-config-standard'
+    };
+   ```
+3. Add `stylelint` script to package.json
+   ```json
+   {
+     "script": {
+      "stylelint": "stylelint \"src/**/*.css\""
+     }
+   }
+   ```
+4. 🚢 it.
+
+## Contributing
+
+* All PR are welcome. 
+* Anything addressed in Limitation is SUPER welcome.
+* Adding tests to `.circleci/config.yml` makes it easier to accept PRs
+
+This project uses Orb testing workflow described in [orb-tools-orb](https://github.com/CircleCI-Public/orb-tools-orb). 
+When you create a PR with a change, it'll automatically run tests and verify the orb. 
+
+You can save yourself a bit of time by running the following before creating the PR,
+
+### Validate the ORB
+
+```bash
+circleci config pack src | circleci config validate
+```
+
+### Validate the config
+
+```bash
+circleci config validate .circleci/config.yml
+```
+
+## Happy shipping!

--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# circleci-react-orb
+
+[CircleCI React Orbs](https://circleci.com/orbs/registry/orb/thefrontside/react) makes it easy to run tests, linting and code coverage on CircleCI.
+
+## Features
+
+- Includes the following jobs: `install`, `test`, `eslint`, `stylelint` and `build`
+- Allows `test`, `eslint`, `stylelint` and `build` to run in parallel
+- `install` job caches NPM dependencies
+- `test` shows test summary in CircleCI
+- `eslint` shows test summary in CircleCI
+- `stylelint` stores generated reports in artifacts
+
+## Limitations
+
+- Currently only supports yarn (we'll add NPM support shortly)
+
+## Example
+
+```yaml
+version: 2.1
+
+orbs:
+  react: thefrontside/react@0.1.0
+
+workflows:
+  # push workflow will be triggered when a new pull request is created
+  push:
+    jobs:
+      - react/install
+      - react/eslint:
+          requires:
+            - react/install
+      - react/stylelint:
+          requires:
+            - react/install
+      - react/test:
+          requires:
+            - react/install
+      - react/coverage:
+          requires:
+            - react/install
+  # push workflow will be triggered when a build is created
+  build:
+    jobs:
+      - react/install
+      - react/eslint:
+          requires:
+            - react/install
+      - react/stylelint:
+          requires:
+            - react/install
+      - react/test:
+          requires:
+            - react/install
+      - react/build:
+            requires:
+              - react/install
+```

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,3 +1,6 @@
+description: >
+  Node 10 runtime environment
+
 parameters:
   node:
     type: string

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -1,5 +1,5 @@
 description: >
-    Build the application in production mode. 
+    Build the application in production mode.
     The built assets are stored in artifacts.
 
 executor: default

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -1,3 +1,7 @@
+description: >
+    Build the application in production mode. 
+    The built assets are stored in artifacts.
+
 executor: default
 
 steps:

--- a/src/jobs/coverage.yml
+++ b/src/jobs/coverage.yml
@@ -1,5 +1,5 @@
 description: >
-    Run the tests and generate coverage reports. 
+    Run the tests and generate coverage reports.
     The results are stored into artifacts.
 
 executor: default

--- a/src/jobs/coverage.yml
+++ b/src/jobs/coverage.yml
@@ -1,3 +1,7 @@
+description: >
+    Run the tests and generate coverage reports. 
+    The results are stored into artifacts.
+
 executor: default
 
 steps:

--- a/src/jobs/eslint.yml
+++ b/src/jobs/eslint.yml
@@ -1,4 +1,4 @@
-descriptor: >
+description: >
     Run ESLint on the source code.
     The generated report is stored in artifacts.
 

--- a/src/jobs/eslint.yml
+++ b/src/jobs/eslint.yml
@@ -1,3 +1,7 @@
+descriptor: >
+    Run ESLint on the source code.
+    The generated report is stored in artifacts.
+
 executor: default
 
 steps:

--- a/src/jobs/install.yml
+++ b/src/jobs/install.yml
@@ -1,5 +1,6 @@
 description: >
-    Checkout and install dependencies
+    Install dependencies. Checkout is called before install.
+    (Optional) To prevent checkout from being called, pass your steps to before_install.
 
 executor: default
 

--- a/src/jobs/stylelint.yml
+++ b/src/jobs/stylelint.yml
@@ -1,3 +1,7 @@
+description: >
+    Run stylelint command on CSS files.
+    The result is stored in artifacts.
+
 executor: default
 
 steps:

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -1,3 +1,6 @@
+description: >
+    Run tests and show results in the test summary.
+
 executor: default
 
 steps:


### PR DESCRIPTION
We want it to be easy for people to use the orb and contribute to it. 

* Adding description to each job and command. 
* Adding README with instructions on how to get `eslint` and `stylelint` setup
* Adding LICENCE file
* Adding Contribution information