### PR TITLE
Fix eslint command to run on all files

### DIFF
--- a/src/commands/eslint.yml
+++ b/src/commands/eslint.yml
@@ -10,3 +10,4 @@ steps:
       --max-warnings=0
       --format junit
       --output-file ./reports/eslint/eslint.xml
+      .


### PR DESCRIPTION
## What was the problem?
The eslint command didnt specify which files to run on, so it never checked anything and always passed with usage info:
```sh
#!/bin/bash -eo pipefail
yarn eslint --max-warnings=0 --format junit --output-file ./reports/eslint/eslint.xml
yarn run v1.19.1
$ /home/circleci/project/node_modules/.bin/eslint --max-warnings=0 --format junit --output-file ./reports/eslint/eslint.xml
eslint [options] file.js [file.js] [dir]
```
See: https://circleci.com/gh/slaweet/github-commit-punch-chart/194

## How did I fix it?
By telling eslint to run on all files in the repo (`.`)

## How did I test it?
I tested it only by running the command locally in my repo, so I'm not sure if this is needed for everyone. Let me know what do you think 🙂 